### PR TITLE
ZON-3228: Adapt imports for `Result` and `IResult`.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,8 +7,6 @@ zeit.retresco changes
 
 - ZON-3364: Implement ``IWhitelist.locations()`` via TMS-API.
 
-- Update to `zeit.cms >= 2.90`.
-
 
 1.5.0 (2016-09-16)
 ------------------

--- a/src/zeit/retresco/connection.py
+++ b/src/zeit/retresco/connection.py
@@ -7,7 +7,6 @@ import pytz
 import requests
 import requests.exceptions
 import zeit.cms.interfaces
-import zeit.cms.result
 import zeit.cms.tagging.interfaces
 import zeit.cms.workflow.interfaces
 import zeit.content.rawxml.interfaces
@@ -72,7 +71,7 @@ class TMS(object):
         response = self._request(
             'GET /topic-pages',
             params={'q': '*', 'page': int(start / rows) + 1, 'rows': rows})
-        result = zeit.cms.result.Result()
+        result = zeit.cms.interfaces.Result()
         result.hits = response['num_found']
         for row in response['docs']:
             row['id'] = zeit.cms.interfaces.normalize_filename(row['doc_id'])
@@ -83,7 +82,7 @@ class TMS(object):
         response = self._request(
             'GET /topic-pages/{}/documents'.format(id),
             params={'page': int(start / rows) + 1, 'rows': rows})
-        result = zeit.cms.result.Result()
+        result = zeit.cms.interfaces.Result()
         result.hits = response['num_found']
         for row in response['docs']:
             page = row['payload']

--- a/src/zeit/retresco/connection.py
+++ b/src/zeit/retresco/connection.py
@@ -7,6 +7,7 @@ import pytz
 import requests
 import requests.exceptions
 import zeit.cms.interfaces
+import zeit.cms.result
 import zeit.cms.tagging.interfaces
 import zeit.cms.workflow.interfaces
 import zeit.content.rawxml.interfaces
@@ -71,7 +72,7 @@ class TMS(object):
         response = self._request(
             'GET /topic-pages',
             params={'q': '*', 'page': int(start / rows) + 1, 'rows': rows})
-        result = zeit.cms.tagging.interfaces.Result()
+        result = zeit.cms.result.Result()
         result.hits = response['num_found']
         for row in response['docs']:
             row['id'] = zeit.cms.interfaces.normalize_filename(row['doc_id'])
@@ -82,7 +83,7 @@ class TMS(object):
         response = self._request(
             'GET /topic-pages/{}/documents'.format(id),
             params={'page': int(start / rows) + 1, 'rows': rows})
-        result = zeit.cms.tagging.interfaces.Result()
+        result = zeit.cms.result.Result()
         result.hits = response['num_found']
         for row in response['docs']:
             page = row['payload']

--- a/src/zeit/retresco/interfaces.py
+++ b/src/zeit/retresco/interfaces.py
@@ -44,7 +44,7 @@ class ITMS(zope.interface.Interface):
         """Returns an iterable of all available topicpage dicts"""
 
     def get_topicpage_documents(id, start=0, rows=25):
-        """Returns an zeit.cms.tagging.interfaces.IResult that contains dicts
+        """Returns an zeit.cms.interfaces.IResult that contains dicts
         with metadata of the content contained in the given TMS topic page.
         The dicts have the following keys:
 

--- a/src/zeit/retresco/tests/test_connection.py
+++ b/src/zeit/retresco/tests/test_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from zeit.cms.result import Result
+from zeit.cms.interfaces import Result
 from zeit.cms.workflow.interfaces import IPublishInfo
 import json
 import lxml.builder

--- a/src/zeit/retresco/tests/test_connection.py
+++ b/src/zeit/retresco/tests/test_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from zeit.cms.tagging.interfaces import Result
+from zeit.cms.result import Result
 from zeit.cms.workflow.interfaces import IPublishInfo
 import json
 import lxml.builder


### PR DESCRIPTION
requires ZeitOnline/zeit.cms#30