### PR TITLE
ZON-3173: Add endpoint for TMS reindexing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,10 +2,10 @@ zeit.retresco changes
 =====================
 
 
-1.8.2 (unreleased)
+1.9.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ZON-3173: Add endpoint for TMS reindexing
 
 
 1.8.1 (2017-02-23)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def project_path(*names):
 
 setup(
     name='zeit.retresco',
-    version='1.8.2.dev0',
+    version='1.9.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/retresco/configure.zcml
+++ b/src/zeit/retresco/configure.zcml
@@ -1,6 +1,5 @@
 <configure
   xmlns="http://namespaces.zope.org/zope"
-  xmlns:browser="http://namespaces.zope.org/browser"
   xmlns:zcml="http://namespaces.zope.org/zcml"
   xmlns:grok="http://namespaces.zope.org/grok"
   i18n_domain="zeit.cms">
@@ -43,13 +42,6 @@
   <permission
     id="zeit.retresco.UpdateIndex"
     title="Update TMS index"
-    />
-
-  <browser:page
-    for="*"
-    name="update_keywords_by_list"
-    class=".json.update.UpdateKeywords"
-    permission="zope.Public"
     />
 
 </configure>

--- a/src/zeit/retresco/configure.zcml
+++ b/src/zeit/retresco/configure.zcml
@@ -1,5 +1,6 @@
 <configure
   xmlns="http://namespaces.zope.org/zope"
+  xmlns:browser="http://namespaces.zope.org/browser"
   xmlns:zcml="http://namespaces.zope.org/zcml"
   xmlns:grok="http://namespaces.zope.org/grok"
   i18n_domain="zeit.cms">
@@ -42,6 +43,13 @@
   <permission
     id="zeit.retresco.UpdateIndex"
     title="Update TMS index"
+    />
+
+  <browser:page
+    for="*"
+    name="update_keywords_by_list"
+    class=".json.update.UpdateKeywords"
+    permission="zope.Public"
     />
 
 </configure>

--- a/src/zeit/retresco/ftesting.zcml
+++ b/src/zeit/retresco/ftesting.zcml
@@ -11,6 +11,7 @@
   <!-- We provide the actual implementation to the mocks registered
        by zeit.cms.tagging. -->
   <includeOverrides package="zeit.retresco" />
+  <include package="zeit.retresco.json" />
   <include package="zeit.retresco.xmlrpc" />
 
   <include package="zeit.content.article" file="ftesting.zcml" />

--- a/src/zeit/retresco/json/configure.zcml
+++ b/src/zeit/retresco/json/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+  xmlns="http://namespaces.zope.org/zope"
+  xmlns:browser="http://namespaces.zope.org/browser"
+  xmlns:zcml="http://namespaces.zope.org/zcml"
+  xmlns:grok="http://namespaces.zope.org/grok"
+  i18n_domain="zeit.cms">
+
+    <browser:page
+    for="zope.location.interfaces.ISite"
+    name="update_keywords"
+    class=".update.UpdateKeywords"
+    permission="zope.Public"
+    />
+
+</configure>

--- a/src/zeit/retresco/json/tests/test_update.py
+++ b/src/zeit/retresco/json/tests/test_update.py
@@ -1,0 +1,54 @@
+import json
+import urllib2
+import zeit.retresco.testing
+import zeit.retresco.update
+import zope.testbrowser.testing
+
+class TMSUpdateRequestTest(zeit.cms.testing.BrowserTestCase):
+
+    layer = zeit.retresco.testing.ZCML_LAYER
+
+    def test_endpoint_avoids_get(self):
+        b = zope.testbrowser.testing.Browser()
+        with self.assertRaisesRegexp(urllib2.HTTPError,
+                                     'HTTP Error 405: Method Not Allowed'):
+            b.open('http://localhost/@@update_keywords')
+
+    def test_endpoint_rejects_post_without_doc_ids(self):
+        b = zope.testbrowser.testing.Browser()
+        with self.assertRaisesRegexp(urllib2.HTTPError,
+                                     'HTTP Error 400: Bad Request'):
+            b.post('http://localhost/@@update_keywords', '')
+        with self.assertRaisesRegexp(urllib2.HTTPError,
+                                     'HTTP Error 400: Bad Request'):
+            b.post('http://localhost/@@update_keywords',
+                   '{"foo" : "bar"}', 'application/x-javascript')
+
+    def test_endpoint_skips_invalid_doc_ids(self):
+        b = zope.testbrowser.testing.Browser()
+        b.post('http://localhost/@@update_keywords',
+               '{"doc_ids" : [1, 2, 3]}', 'application/x-javascript')
+        status = {
+            'updated_content': [],
+            'updated': [],
+            'message': 'Nothing updated',
+            'invalid': [1, 2, 3]}
+        self.assertEquals(status, json.loads(b.contents))
+        self.assertEquals('200 Ok', b.headers.getheader('status'))
+
+    def test_endpoint_successful_update_vaild_article(self):
+        b = zope.testbrowser.testing.Browser()
+        b.post('http://localhost/@@update_keywords',
+               '{"doc_ids" : ['
+                '"{urn:uuid:9cb93717-2467-4af5-9521-25110e1a7ed8}", '
+                '"{urn:uuid:0da8cb59-1a72-4ae2-bbe2-006e6b1ff621}"]}',
+                'application/x-javascript')
+        status = {
+            'updated_content': ['http://xml.zeit.de/online/2007/01/Somalia',
+                                'http://xml.zeit.de/online/2007/01/Somalia'],
+            'updated': ['{urn:uuid:9cb93717-2467-4af5-9521-25110e1a7ed8}',
+                        '{urn:uuid:0da8cb59-1a72-4ae2-bbe2-006e6b1ff621}'],
+            'message': 'Update successful',
+            'invalid': []}
+        self.assertEquals(status, json.loads(b.contents))
+        self.assertEquals('200 Ok', b.headers.getheader('status'))

--- a/src/zeit/retresco/json/update.py
+++ b/src/zeit/retresco/json/update.py
@@ -13,7 +13,6 @@ class UpdateKeywords(zeit.cms.browser.view.Base):
                 not self.request.form.get('_body_decoded')):
             decoded = self.request.bodyStream.read(
                 int(self.request['CONTENT_LENGTH']))
-
             try:
                 for doc_id in json.loads(decoded).get('doc_ids'):
                     try:

--- a/src/zeit/retresco/json/update.py
+++ b/src/zeit/retresco/json/update.py
@@ -1,14 +1,22 @@
 from zeit.retresco.update import index_async
 import json
 import logging
-import zeit.cms.browser.view
+import zeit.cms.content.contentuuid
+import zeit.cms.content.interfaces
 
 log = logging.getLogger(__name__)
 
 
-class UpdateKeywords(zeit.cms.browser.view.Base):
+class UpdateKeywords(object):
 
+    # A hopefully more correct version than zeit.cms.browser.view.JSON
     def __call__(self):
+        self.request.response.setHeader('Content-Type', 'application/json')
+        status, result = self.update()
+        self.request.response.setStatus(status)
+        return json.dumps(result)
+
+    def update(self):
         status = {
             'message': '',
             'invalid': [],
@@ -18,8 +26,7 @@ class UpdateKeywords(zeit.cms.browser.view.Base):
 
         if self.request.method != 'POST':
             status['message'] = 'Only POST supported'
-            self.request.response.setStatus(405)
-            return json.dumps(status)
+            return 405, status
 
         try:
             body = self.request.bodyStream.read(
@@ -28,8 +35,7 @@ class UpdateKeywords(zeit.cms.browser.view.Base):
         except:
             status['message'] = (
                 'JSON body with parameter doc_ids (list of uuids) required')
-            self.request.response.setStatus(400)
-            return json.dumps(status)
+            return 400, status
 
         for doc_id in doc_ids:
             try:
@@ -46,4 +52,4 @@ class UpdateKeywords(zeit.cms.browser.view.Base):
         status['message'] = 'Nothing updated'
         if status['updated']:
             status['message'] = 'Update successful'
-        return json.dumps(status)
+        return 200, status

--- a/src/zeit/retresco/json/update.py
+++ b/src/zeit/retresco/json/update.py
@@ -9,30 +9,38 @@ log = logging.getLogger(__name__)
 class UpdateKeywords(zeit.cms.browser.view.Base):
 
     def __call__(self):
-        if (self.request.method == 'POST' and
-                not self.request.form.get('_body_decoded')):
-            decoded = self.request.bodyStream.read(
-                int(self.request['CONTENT_LENGTH']))
-            try:
-                for doc_id in json.loads(decoded).get('doc_ids'):
-                    try:
-                        content = zeit.cms.content.contentuuid.uuid_to_content(
-                            zeit.cms.content.interfaces.IUUID(doc_id))
-                        index_async(content.uniqueId, True, True)
-                    except (AttributeError, TypeError):
-                        log.warning('Error invalid UUID %s', doc_id,
-                                    exc_info=True)
-                        self.request.response.setStatus(422)
-                        return json.dumps({"update": False})
-            except (TypeError, ValueError):
-                log.warning('Request invalid', exc_info=True)
-                self.request.response.setStatus(400)
-                return json.dumps({"update": False})
 
-            log.info('Update successful')
-            return json.dumps({"update": True})
+        status = {'updated': [], 'invalid': [], 'updated_content': [],
+                'message': ''}
 
-        else:
-            log.warning('Request invalid')
+        if self.request.method != 'POST':
+            status['message'] = 'Only POST supported'
+            self.request.response.setStatus(405)
+            return json.dumps(status)
+
+        body = self.request.bodyStream.read(
+            int(self.request['CONTENT_LENGTH']))
+        try:
+            for doc_id in json.loads(body).get('doc_ids'):
+                try:
+                    content = zeit.cms.content.contentuuid.uuid_to_content(
+                        zeit.cms.content.interfaces.IUUID(doc_id))
+                    index_async(content.uniqueId, True, True)
+                    status['updated'].append(doc_id)
+                    status['updated_content'].append(content.uniqueId)
+                except (AttributeError, TypeError):
+                    status['invalid'].append(doc_id)
+                    pass
+            status['message'] = 'Nothing updated'
+            if status['updated']:
+                log.info('Update successful')
+                status['message'] = 'Update successful'
+            return json.dumps(status)
+
+        except (TypeError, ValueError):
+            log.warning('JSON body with parameter doc_ids (list of uuids) '
+                        'required', exc_info=True)
+            status['message'] = ('JSON body with parameter doc_ids '
+                                 '(list of uuids) required')
             self.request.response.setStatus(400)
-            return json.dumps({"update": False})
+            return json.dumps(status)

--- a/src/zeit/retresco/json/update.py
+++ b/src/zeit/retresco/json/update.py
@@ -1,0 +1,39 @@
+from zeit.retresco.update import index_async
+import json
+import logging
+import zeit.cms.browser.view
+
+log = logging.getLogger(__name__)
+
+
+class UpdateKeywords(zeit.cms.browser.view.Base):
+
+    def __call__(self):
+        if (self.request.method == 'POST' and
+                not self.request.form.get('_body_decoded')):
+            decoded = self.request.bodyStream.read(
+                int(self.request['CONTENT_LENGTH']))
+
+            try:
+                for doc_id in json.loads(decoded).get('doc_ids'):
+                    try:
+                        content = zeit.cms.content.contentuuid.uuid_to_content(
+                            zeit.cms.content.interfaces.IUUID(doc_id))
+                        index_async(content.uniqueId)
+                    except (AttributeError, TypeError):
+                        log.warning('Error invalid UUID %s', doc_id,
+                                    exc_info=True)
+                        self.request.response.setStatus(422)
+                        return json.dumps({"update": False})
+            except (TypeError, ValueError):
+                log.warning('Request invalid', exc_info=True)
+                self.request.response.setStatus(400)
+                return json.dumps({"update": False})
+
+            log.info('Update successful')
+            return json.dumps({"update": True})
+
+        else:
+            log.warning('Request invalid')
+            self.request.response.setStatus(400)
+            return json.dumps({"update": False})

--- a/src/zeit/retresco/json/update.py
+++ b/src/zeit/retresco/json/update.py
@@ -9,9 +9,12 @@ log = logging.getLogger(__name__)
 class UpdateKeywords(zeit.cms.browser.view.Base):
 
     def __call__(self):
-
-        status = {'updated': [], 'invalid': [], 'updated_content': [],
-                'message': ''}
+        status = {
+            'message': '',
+            'invalid': [],
+            'updated': [],
+            'updated_content': [],
+        }
 
         if self.request.method != 'POST':
             status['message'] = 'Only POST supported'
@@ -30,17 +33,16 @@ class UpdateKeywords(zeit.cms.browser.view.Base):
                     status['updated_content'].append(content.uniqueId)
                 except (AttributeError, TypeError):
                     status['invalid'].append(doc_id)
-                    pass
+                    continue
+                else:
+                    log.info('Scheduling %s for reindex', content.uniqueId)
             status['message'] = 'Nothing updated'
             if status['updated']:
-                log.info('Update successful')
                 status['message'] = 'Update successful'
             return json.dumps(status)
 
         except (TypeError, ValueError):
-            log.warning('JSON body with parameter doc_ids (list of uuids) '
-                        'required', exc_info=True)
-            status['message'] = ('JSON body with parameter doc_ids '
-                                 '(list of uuids) required')
+            status['message'] = (
+                'JSON body with parameter doc_ids (list of uuids) required')
             self.request.response.setStatus(400)
             return json.dumps(status)

--- a/src/zeit/retresco/json/update.py
+++ b/src/zeit/retresco/json/update.py
@@ -21,28 +21,29 @@ class UpdateKeywords(zeit.cms.browser.view.Base):
             self.request.response.setStatus(405)
             return json.dumps(status)
 
-        body = self.request.bodyStream.read(
-            int(self.request['CONTENT_LENGTH']))
         try:
-            for doc_id in json.loads(body).get('doc_ids'):
-                try:
-                    content = zeit.cms.content.contentuuid.uuid_to_content(
-                        zeit.cms.content.interfaces.IUUID(doc_id))
-                    index_async(content.uniqueId, True, True)
-                    status['updated'].append(doc_id)
-                    status['updated_content'].append(content.uniqueId)
-                except (AttributeError, TypeError):
-                    status['invalid'].append(doc_id)
-                    continue
-                else:
-                    log.info('Scheduling %s for reindex', content.uniqueId)
-            status['message'] = 'Nothing updated'
-            if status['updated']:
-                status['message'] = 'Update successful'
-            return json.dumps(status)
-
-        except (TypeError, ValueError):
+            body = self.request.bodyStream.read(
+                int(self.request['CONTENT_LENGTH']))
+            doc_ids = json.loads(body)['doc_ids']
+        except:
             status['message'] = (
                 'JSON body with parameter doc_ids (list of uuids) required')
             self.request.response.setStatus(400)
             return json.dumps(status)
+
+        for doc_id in doc_ids:
+            try:
+                content = zeit.cms.content.contentuuid.uuid_to_content(
+                    zeit.cms.content.interfaces.IUUID(doc_id))
+                index_async(content.uniqueId, True, True)
+                status['updated'].append(doc_id)
+                status['updated_content'].append(content.uniqueId)
+            except (AttributeError, TypeError):
+                status['invalid'].append(doc_id)
+                continue
+            else:
+                log.info('Scheduling %s for reindex', content.uniqueId)
+        status['message'] = 'Nothing updated'
+        if status['updated']:
+            status['message'] = 'Update successful'
+        return json.dumps(status)

--- a/src/zeit/retresco/json/update.py
+++ b/src/zeit/retresco/json/update.py
@@ -18,7 +18,7 @@ class UpdateKeywords(zeit.cms.browser.view.Base):
                     try:
                         content = zeit.cms.content.contentuuid.uuid_to_content(
                             zeit.cms.content.interfaces.IUUID(doc_id))
-                        index_async(content.uniqueId)
+                        index_async(content.uniqueId, True, True)
                     except (AttributeError, TypeError):
                         log.warning('Error invalid UUID %s', doc_id,
                                     exc_info=True)

--- a/src/zeit/retresco/search.py
+++ b/src/zeit/retresco/search.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import elasticsearch
 import json
 import zeit.cms.interfaces

--- a/src/zeit/retresco/testing.py
+++ b/src/zeit/retresco/testing.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import gocept.httpserverlayer.custom
 import json
 import mock

--- a/src/zeit/retresco/tests/test_update.py
+++ b/src/zeit/retresco/tests/test_update.py
@@ -14,7 +14,6 @@ import zeit.workflow.testing
 import zope.component
 import zope.event
 import zope.lifecycleevent
-import mechanize
 
 
 @gocept.async.function(service='events')
@@ -167,41 +166,3 @@ class UpdateTest(zeit.retresco.testing.FunctionalTestCase):
         zeit.cms.workflow.interfaces.IPublishInfo(content).urgent = True
         zeit.cms.workflow.interfaces.IPublish(content).publish()
         zeit.workflow.testing.run_publish()
-
-
-class TMSUpdateRequestTest(zeit.cms.testing.BrowserTestCase):
-
-    layer = zeit.retresco.testing.ZCML_LAYER
-
-    def test_endpoint_avoids_get(self):
-        b = zope.testbrowser.testing.Browser()
-        with self.assertRaisesRegexp(mechanize.HTTPError,
-                                     'HTTP Error 400: Bad Request'):
-            b.open('http://localhost/@@update_keywords_by_list')
-
-    def test_endpoint_rejects_post_without_doc_ids(self):
-        b = zope.testbrowser.testing.Browser()
-        with self.assertRaisesRegexp(mechanize.HTTPError,
-                                     'HTTP Error 400: Bad Request'):
-            b.post('http://localhost/@@update_keywords_by_list', '')
-        with self.assertRaisesRegexp(mechanize.HTTPError,
-                                     'HTTP Error 400: Bad Request'):
-            b.post('http://localhost/@@update_keywords_by_list',
-                   '{"foo" : "bar"}', 'application/x-javascript')
-
-    def test_endpoint_rejects_invalid_doc_ids(self):
-        b = zope.testbrowser.testing.Browser()
-        with self.assertRaisesRegexp(mechanize.HTTPError,
-                                     'HTTP Error 422: Unprocessable Entity'):
-            b.post('http://localhost/@@update_keywords_by_list',
-                   '{"doc_ids" : [1, 2, 3]}', 'application/x-javascript')
-
-    def test_endpoint_successful_update_vaild_article(self):
-        b = zope.testbrowser.testing.Browser()
-        b.post('http://localhost/@@update_keywords_by_list',
-               '{"doc_ids" : ['
-                '"{urn:uuid:9cb93717-2467-4af5-9521-25110e1a7ed8}", '
-                '"{urn:uuid:0da8cb59-1a72-4ae2-bbe2-006e6b1ff621}"]}',
-                'application/x-javascript')
-        self.assertEquals('{"update": true}', b.contents)
-        self.assertEquals('200 Ok', b.headers.getheader('status'))

--- a/src/zeit/retresco/tests/test_update.py
+++ b/src/zeit/retresco/tests/test_update.py
@@ -14,6 +14,7 @@ import zeit.workflow.testing
 import zope.component
 import zope.event
 import zope.lifecycleevent
+import mechanize
 
 
 @gocept.async.function(service='events')
@@ -166,3 +167,41 @@ class UpdateTest(zeit.retresco.testing.FunctionalTestCase):
         zeit.cms.workflow.interfaces.IPublishInfo(content).urgent = True
         zeit.cms.workflow.interfaces.IPublish(content).publish()
         zeit.workflow.testing.run_publish()
+
+
+class TMSUpdateRequestTest(zeit.cms.testing.BrowserTestCase):
+
+    layer = zeit.retresco.testing.ZCML_LAYER
+
+    def test_endpoint_avoids_get(self):
+        b = zope.testbrowser.testing.Browser()
+        with self.assertRaisesRegexp(mechanize.HTTPError,
+                                     'HTTP Error 400: Bad Request'):
+            b.open('http://localhost/@@update_keywords_by_list')
+
+    def test_endpoint_rejects_post_without_doc_ids(self):
+        b = zope.testbrowser.testing.Browser()
+        with self.assertRaisesRegexp(mechanize.HTTPError,
+                                     'HTTP Error 400: Bad Request'):
+            b.post('http://localhost/@@update_keywords_by_list', '')
+        with self.assertRaisesRegexp(mechanize.HTTPError,
+                                     'HTTP Error 400: Bad Request'):
+            b.post('http://localhost/@@update_keywords_by_list',
+                   '{"foo" : "bar"}', 'application/x-javascript')
+
+    def test_endpoint_rejects_invalid_doc_ids(self):
+        b = zope.testbrowser.testing.Browser()
+        with self.assertRaisesRegexp(mechanize.HTTPError,
+                                     'HTTP Error 422: Unprocessable Entity'):
+            b.post('http://localhost/@@update_keywords_by_list',
+                   '{"doc_ids" : [1, 2, 3]}', 'application/x-javascript')
+
+    def test_endpoint_successful_update_vaild_article(self):
+        b = zope.testbrowser.testing.Browser()
+        b.post('http://localhost/@@update_keywords_by_list',
+               '{"doc_ids" : ['
+                '"{urn:uuid:9cb93717-2467-4af5-9521-25110e1a7ed8}", '
+                '"{urn:uuid:0da8cb59-1a72-4ae2-bbe2-006e6b1ff621}"]}',
+                'application/x-javascript')
+        self.assertEquals('{"update": true}', b.contents)
+        self.assertEquals('200 Ok', b.headers.getheader('status'))


### PR DESCRIPTION
Needs deployment configuration: https://github.com/ZeitOnline/vivi-deployment/pull/28

Correct call:
`http post  :8080/@@update_keywords doc_ids:='["{urn:uuid:a228fb93-77e3-486e-bf5e-8fe6b5607bda}"]'` -> 200 OK
`{
    "invalid": [],
    "message": "Update successful",
    "updated": [
        "{urn:uuid:a228fb93-77e3-486e-bf5e-8fe6b5607bda}"
    ],
    "updated_content": [
        "http://xml.zeit.de/test/wosc/arttest"
    ]
}`


Invalid calls:
`http post :8080/@@update_keywords foo=bar` -> 400 Bad Request
`{
    "invalid": [],
    "message": "JSON body with parameter doc_ids (list of uuids) required",
    "updated": [],
    "updated_content": []
}`


`http post :8080/@@update_keywords doc_ids='abc'` -> 200
`{
    "invalid": [
        "a",
        "b",
        "c"
    ],
    "message": "Nothing updated",
    "updated": [],
    "updated_content": []
}`


`http post :8080/@@update_keywords doc_ids:='["abc"]'` -> 200
`{
    "invalid": [
        "abc"
    ],
    "message": "Nothing updated",
    "updated": [],
    "updated_content": []
}`


`http :8080/@@update_keywords`-> 405 Method not allowed
`{
    "invalid": [],
    "message": "Method not allowed",
    "updated": [],
    "updated_content": []
}`