### PR TITLE
PERF: Don't resolve anything in re-enrich hook

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ zeit.retresco changes
 1.10.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- PERF: Don't resolve anything in re-enrich hook,
+  just create async jobs, so we can handle large content amounts
 
 
 1.10.4 (2017-07-07)

--- a/src/zeit/retresco/json/update.py
+++ b/src/zeit/retresco/json/update.py
@@ -1,8 +1,8 @@
-from zeit.retresco.update import index_async
 import json
 import logging
 import zeit.cms.content.contentuuid
 import zeit.cms.content.interfaces
+import zeit.retresco.update
 
 log = logging.getLogger(__name__)
 
@@ -12,44 +12,35 @@ class UpdateKeywords(object):
     # A hopefully more correct version than zeit.cms.browser.view.JSON
     def __call__(self):
         self.request.response.setHeader('Content-Type', 'application/json')
-        status, result = self.update()
+        status, message = self.update()
         self.request.response.setStatus(status)
-        return json.dumps(result)
+        return json.dumps({'message': message})
 
     def update(self):
-        status = {
-            'message': '',
-            'invalid': [],
-            'updated': [],
-            'updated_content': [],
-        }
-
         if self.request.method != 'POST':
-            status['message'] = 'Only POST supported'
-            return 405, status
+            return 405, 'Only POST supported'
 
         try:
             body = self.request.bodyStream.read(
                 int(self.request['CONTENT_LENGTH']))
             doc_ids = json.loads(body)['doc_ids']
         except:
-            status['message'] = (
+            message = (
                 'JSON body with parameter doc_ids (list of uuids) required')
-            return 400, status
+            return 400, message
 
         for doc_id in doc_ids:
-            try:
-                content = zeit.cms.content.contentuuid.uuid_to_content(
-                    zeit.cms.content.interfaces.IUUID(doc_id))
-                index_async(content.uniqueId, True, True)
-                status['updated'].append(doc_id)
-                status['updated_content'].append(content.uniqueId)
-            except (AttributeError, TypeError):
-                status['invalid'].append(doc_id)
-                continue
-            else:
-                log.info('Scheduling %s for reindex', content.uniqueId)
-        status['message'] = 'Nothing updated'
-        if status['updated']:
-            status['message'] = 'Update successful'
-        return 200, status
+            update_async(doc_id)
+        return 200, 'OK'
+
+
+@zeit.cms.async.function(queue='search')
+def update_async(uuid):
+    try:
+        content = zeit.cms.content.contentuuid.uuid_to_content(
+            zeit.cms.content.interfaces.IUUID(uuid))
+    except:
+        log.warning('TMS wants to update invalid id %s, ignored', uuid)
+    else:
+        zeit.retresco.update.index(
+            content.uniqueId, entrich=True, publish=True)


### PR DESCRIPTION
When TMS wants to re-index a lot of content, resolving the uuid may be
too slow (especially for older content that's not in the DAV cache),
so we move the resolving inside the async job, so the view doesn't
have to do any more work than absolutely necessary.