### PR TITLE
TMS-149: Retry indexing on technical errors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ zeit.retresco changes
 1.15.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- TMS-149: Retry indexing on technical errors
 
 
 1.15.7 (2018-01-22)

--- a/src/zeit/retresco/testing.py
+++ b/src/zeit/retresco/testing.py
@@ -91,6 +91,11 @@ ZCML_LAYER = ZCMLLayer(
     zeit.content.image.testing.product_config)
 
 
+CELERY_LAYER = zeit.cms.testing.CeleryWorkerLayer(
+    name='CeleryLayer', bases=(ZCML_LAYER,))
+CELERY_LAYER.queues += ('search',)
+
+
 MOCK_ZCML_LAYER = plone.testing.Layer(
     bases=(ZCML_LAYER, ELASTICSEARCH_MOCK_LAYER), name='MockZCMLLayer',
     module=__name__)

--- a/src/zeit/retresco/tests/test_update.py
+++ b/src/zeit/retresco/tests/test_update.py
@@ -2,7 +2,6 @@ from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import mock
 import transaction
 import zeit.cms.checkout.helper
-import zeit.cms.repository
 import zeit.cms.workflow.interfaces
 import zeit.cms.workingcopy.workingcopy
 import zeit.retresco.testing
@@ -10,7 +9,6 @@ import zeit.retresco.update
 import zope.component
 import zope.event
 import zope.lifecycleevent
-import zope.security.management
 
 
 class UpdateTest(zeit.retresco.testing.FunctionalTestCase):
@@ -23,11 +21,9 @@ class UpdateTest(zeit.retresco.testing.FunctionalTestCase):
         self.zca.patch_utility(self.tms, zeit.retresco.interfaces.ITMS)
 
     def test_creating_content_should_index(self):
-        repository = zope.component.getUtility(
-            zeit.cms.repository.interfaces.IRepository)
-        repository['t1'] = ExampleContentType()
-        self.tms.enrich.assert_called_with(repository['t1'])
-        self.tms.index.assert_called_with(repository['t1'], None)
+        self.repository['t1'] = ExampleContentType()
+        self.tms.enrich.assert_called_with(self.repository['t1'])
+        self.tms.index.assert_called_with(self.repository['t1'], None)
 
     def test_event_dispatched_to_sublocation_should_be_ignored(self):
         # XXX: I'm not quite sure which use cases actually create this kind of


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/z3c.celery/pull/32 which you can include into your vivi sandbox via

```diff
diff --git a/components/source/component.py b/components/source/component.py
index be5cd5a..3c4aaba 100644
--- a/components/source/component.py
+++ b/components/source/component.py
@@ -56,7 +56,7 @@ class Source(batou_scm.source.Source):
     ]

     third_party = [  # do not tests these packages
     -        # 'z3c.celery',
     +        'z3c.celery branch=retry',
              # 'celery_longterm_scheduler',
                   ]

```