### PR TITLE
MAINT: Allow explicit source field filtering

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ zeit.retresco changes
 1.21.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- MAINT: Allow explicit source field selection while maintaining compat with
+  `include_payload` search flag.
 
 
 1.21.3 (2018-04-27)


### PR DESCRIPTION
Allows our elasticsearch client to [specify returned fields explicitly](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html) or just return all by using the established `include_payload` flag.

Originally implemented this for TMS-165, but didn't need it then. However, I think it could still be useful in the future.