### PR TITLE
MAINT: Change redirect syntax to zeit.web instead of nginx

### DIFF
--- a/src/zeit/retresco/connection.py
+++ b/src/zeit/retresco/connection.py
@@ -321,7 +321,7 @@ def _build_topic_redirects(topicpages):
             target = url_prefix + target
         # XXX hard-coded path
         source = u'/thema/' + row['id']
-        output.write('location = %s { return 301 %s; }\n' % (source, target))
+        output.write('%s = %s\n' % (source, target))
 
     return output.getvalue()
 

--- a/src/zeit/retresco/tests/test_connection.py
+++ b/src/zeit/retresco/tests/test_connection.py
@@ -377,8 +377,7 @@ class TopiclistUpdateTest(zeit.retresco.testing.FunctionalTestCase):
         }]
         text = zeit.retresco.connection._build_topic_redirects(pages)
         self.assertEllipsis(
-            '...location = /thema/berlin { return 301 '
-            'http://www.zeit.de/thema/hamburg; }...', text)
+            '.../thema/berlin = http://www.zeit.de/thema/hamburg\n', text)
 
 
 class SlowAdapter(requests.adapters.BaseAdapter):


### PR DESCRIPTION
Erst deployen wenn https://github.com/ZeitOnline/zeit.web/pull/2887 in Production eingerichtet ist.