### PR TITLE
TMS-214: Revive `payload.teaser.title` to make the author auto-complete work again.

### DIFF
--- a/src/zeit/retresco/convert.py
+++ b/src/zeit/retresco/convert.py
@@ -310,6 +310,8 @@ class Author(Converter):
                 'supertitle': self.context.summary,
                 'title': self.context.display_name,
                 'text': self.context.biography,
+            }, 'teaser': {
+                'title': self.context.display_name,
             }}
         }
 

--- a/src/zeit/retresco/tests/test_convert.py
+++ b/src/zeit/retresco/tests/test_convert.py
@@ -364,6 +364,12 @@ class ConvertTest(zeit.retresco.testing.FunctionalTestCase,
             'title': 'William Shakespeare',
             'text': '...or not to be!',
         }, data['payload']['body'])
+        # FIXME: p.teaser.title is required for the author auto-complete
+        # until https://github.com/ZeitOnline/tms-deployment/pull/16 has
+        # been deployed (by retresco)
+        self.assertEqual({
+            'title': 'William Shakespeare',
+        }, data['payload']['teaser'])
 
     def test_converts_text(self):
         text = zeit.content.text.text.Text()


### PR DESCRIPTION
The author auto-complete feature depends on the `payload.vivi.autocomplete` field, which in turn is copied from `payload.teaser.title` (see https://github.com/ZeitOnline/tms-deployment/pull/15).  However, this was recently removed in an attempt to clean up things (https://github.com/ZeitOnline/zeit.retresco/pull/38).  Since we need Retresco to update the Elasticsearch mapping (https://github.com/ZeitOnline/tms-deployment/pull/16) we'll restore the field for the time being...