### PR TITLE
ZON-4820: Add `ISkipEnrich` marker interface that skips automatic enrich on checkin

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.retresco changes
 =====================
 
-1.31.2 (unreleased)
+1.32.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-4820: Add `ISkipEnrich` marker interface that skips automatic enrich on checkin
 
 
 1.31.1 (2018-08-16)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def project_path(*names):
 
 setup(
     name='zeit.retresco',
-    version='1.31.2.dev0',
+    version='1.32.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/retresco/interfaces.py
+++ b/src/zeit/retresco/interfaces.py
@@ -154,6 +154,16 @@ class IBody(zope.interface.Interface):
     """
 
 
+class ISkipEnrich(zope.interface.Interface):
+    """Marker interface to denote ICMSContent that should not be enriched
+    automatically.
+
+    Current example: centerpages provide this, because their body contains
+    no sensibly enricheable text (it's just control information), and thus
+    enriching them only wastes time.
+    """
+
+
 class ITMSContent(zeit.cms.interfaces.ICMSContent):
     """Adapts a TMS or Elasticsearch result dict to an ICMSContent object.
 

--- a/src/zeit/retresco/tests/test_update.py
+++ b/src/zeit/retresco/tests/test_update.py
@@ -66,6 +66,15 @@ class UpdateTest(zeit.retresco.testing.FunctionalTestCase):
                 pass
             self.assertTrue(index.apply_async.called)
 
+    def test_checkin_should_enrich_marked_content(self):
+        content = ExampleContentType()
+        zope.interface.alsoProvides(
+            content, zeit.retresco.interfaces.ISkipEnrich)
+        self.repository['t1'] = content
+        with zeit.cms.checkout.helper.checked_out(self.repository['t1']):
+            pass
+        self.assertFalse(self.tms.enrich.called)
+
     def test_folders_should_be_indexed_recursively(self):
         folder = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/2007/01')
         zeit.retresco.update.index(folder)

--- a/src/zeit/retresco/update.py
+++ b/src/zeit/retresco/update.py
@@ -1,4 +1,5 @@
 from zeit.cms.repository.interfaces import ICollection, INonRecursiveCollection
+from zeit.retresco.interfaces import ISkipEnrich
 import argparse
 import gocept.runner
 import grokcore.component as grok
@@ -93,7 +94,7 @@ def index(content, enrich=False, update_keywords=False, publish=False):
         log.info('Updating: %s %s, enrich: %s, keywords: %s, publish: %s',
                  content.uniqueId, uuid, enrich, update_keywords, publish)
         try:
-            if enrich:
+            if enrich and not ISkipEnrich.providedBy(content):
                 log.debug('Enriching: %s', content.uniqueId)
                 response = conn.enrich(content)
                 body = response.get('body')


### PR DESCRIPTION
Das können wir dann übrigens auch auf den `/hilfe/datenschutz` manuell draufpacken (`zope debug provide_interface.py`), als Workaround dafür dass der Artikel zu lang ist und Enrich immer timeouted.