### PR TITLE
ZON-4893: Decouple indexing during publish from the checkout/checkin cycle

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.retresco changes
 1.31.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-4893: Index during publish for all content types
 
 
 1.31.1 (2018-08-16)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ zeit.retresco changes
 1.31.2 (unreleased)
 -------------------
 
-- ZON-4893: Index during publish for all content types
+- ZON-4893: Index during publish for all content types,
+  index after retract too.
 
 
 1.31.1 (2018-08-16)

--- a/src/zeit/retresco/tests/test_update.py
+++ b/src/zeit/retresco/tests/test_update.py
@@ -165,6 +165,23 @@ class UpdatePublishTest(zeit.retresco.testing.FunctionalTestCase):
         zeit.cms.workflow.interfaces.IPublish(content).publish(async=False)
         self.assertEqual([True, True], published)
 
+    def test_retract_should_index_with_published_false(self):
+        published = []
+
+        def index(content, override_body=None):
+            published.append(zeit.cms.workflow.interfaces.IPublishInfo(
+                content).published)
+        self.tms.index = index
+        content = self.repository['testcontent']
+        zeit.cms.workflow.interfaces.IPublishInfo(content).published = True
+        zeit.cms.workflow.interfaces.IPublish(content).retract(async=False)
+        self.assertEqual([False], published)
+
+        content = self.repository['2006']['DSC00109_2.JPG']
+        zeit.cms.workflow.interfaces.IPublishInfo(content).published = True
+        zeit.cms.workflow.interfaces.IPublish(content).retract(async=False)
+        self.assertEqual([False, False], published)
+
 
 class IndexParallelTest(zeit.retresco.testing.FunctionalTestCase):
 

--- a/src/zeit/retresco/tests/test_update.py
+++ b/src/zeit/retresco/tests/test_update.py
@@ -143,21 +143,22 @@ class UpdateTest(zeit.retresco.testing.FunctionalTestCase):
 
 class UpdatePublishTest(zeit.retresco.testing.FunctionalTestCase):
 
-    layer = zeit.retresco.testing.CELERY_LAYER
-
     def setUp(self):
         super(UpdatePublishTest, self).setUp()
         self.tms = mock.Mock()
         self.zca.patch_utility(self.tms, zeit.retresco.interfaces.ITMS)
 
     def test_publish_should_index_with_published_true(self):
-        def index(content):
-            self.assertTrue(zeit.cms.workflow.interfaces.IPublishInfo(
+        published = []
+
+        def index(content, override_body=None):
+            published.append(zeit.cms.workflow.interfaces.IPublishInfo(
                 content).published)
         self.tms.index = index
         content = self.repository['testcontent']
         zeit.cms.workflow.interfaces.IPublishInfo(content).urgent = True
         zeit.cms.workflow.interfaces.IPublish(content).publish(async=False)
+        self.assertEqual([True], published)
 
 
 class IndexParallelTest(zeit.retresco.testing.FunctionalTestCase):

--- a/src/zeit/retresco/tests/test_update.py
+++ b/src/zeit/retresco/tests/test_update.py
@@ -160,6 +160,11 @@ class UpdatePublishTest(zeit.retresco.testing.FunctionalTestCase):
         zeit.cms.workflow.interfaces.IPublish(content).publish(async=False)
         self.assertEqual([True], published)
 
+        content = self.repository['2006']['DSC00109_2.JPG']
+        zeit.cms.workflow.interfaces.IPublishInfo(content).urgent = True
+        zeit.cms.workflow.interfaces.IPublish(content).publish(async=False)
+        self.assertEqual([True, True], published)
+
 
 class IndexParallelTest(zeit.retresco.testing.FunctionalTestCase):
 


### PR DESCRIPTION
This way is not only cleaner, but also works for non-xml content (since those are not cycled)

Needs https://github.com/ZeitOnline/zeit.cms/pull/88